### PR TITLE
ci: add passphrase to deploy step

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -216,4 +216,5 @@ jobs:
           host: ${{ secrets.HOST }}
           USERNAME: ${{ secrets.USERNAME }}
           KEY: ${{ secrets.SSHKEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
           script: docker service update --image njausteve/njausteve:${{ github.sha }} njausteve_app


### PR DESCRIPTION
 to fix ssh.ParsePrivateKey: ssh: private key is passphrase protected error

Signed-off-by: Stephen <njaustevedomino@gmail.com>