### PR TITLE
Change productions https configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,6 @@ npm-debug.log
 # docker environment secrets
 *.env
 
-# tmp folders
+# site_encrypt folders
+certdb
 tmp

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -35,6 +35,8 @@ config :njausteve, NjausteveWeb.Endpoint,
   https: [
     port: 443,
     cipher_suite: :strong,
+    keyfile: System.get_env("SOME_APP_SSL_KEY_PATH"),
+    certfile: System.get_env("SOME_APP_SSL_CERT_PATH"),
     transport_options: [socket_opts: [:inet6]]
   ]
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -11,7 +11,12 @@ import Config
 # before starting your production server.
 config :njausteve, NjausteveWeb.Endpoint,
   url: [host: "njausteve.com", port: 443, scheme: "https"],
-  cache_static_manifest: "priv/static/cache_manifest.json"
+  cache_static_manifest: "priv/static/cache_manifest.json",
+  https: [
+    port: 4001,
+    cipher_suite: :strong,
+    transport_options: [socket_opts: [:inet6]]
+  ]
 
 config :sentry,
   dsn: "https://67b7e30a79f241f188a099b75d061862@o543662.ingest.sentry.io/5869754",
@@ -30,16 +35,6 @@ config :logger, level: :info
 #
 # To get SSL working, you will need to add the `https` key
 # to the previous section and set your `:url` port to 443:
-#
-config :njausteve, NjausteveWeb.Endpoint,
-  https: [
-    port: 443,
-    cipher_suite: :strong,
-    keyfile: System.get_env("SOME_APP_SSL_KEY_PATH"),
-    certfile: System.get_env("SOME_APP_SSL_CERT_PATH"),
-    transport_options: [socket_opts: [:inet6]]
-  ]
-
 # The `cipher_suite` is set to `:strong` to support only the
 # latest and more secure SSL ciphers. This means old browsers
 # and clients may not be supported. You can set it to

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     image: postgres:11.10-alpine
     env_file:
       - docker.env
-    restart: always
     volumes:
       - pgdata:/var/lib/postgresql/data
     ports:
@@ -18,12 +17,14 @@ services:
     networks:
       - webnet
   app:
-    image: njausteve/njausteve:9d7f707af08e06ed0591759cfc48c84344b2a1e3
+    image: njausteve/njausteve:Jca9sJEDHGIZw6qByATZ73Y8bwBxYnvfxt
     env_file:
       - docker.env
+    volumes:
+      - ./site_encrypt_db:/site_encrypt_db
     ports:
       - "80:4000"
-    restart: always
+      - "443:4001"
     depends_on:
       - db
     deploy:


### PR DESCRIPTION
This pr fixes production https configuration and exposes port 4001 where the secure version is served. This ensures that site_encrypt will work as should